### PR TITLE
Feat/iac/swarm mode setup

### DIFF
--- a/iac/client/Dockerfile
+++ b/iac/client/Dockerfile
@@ -5,10 +5,10 @@ FROM golang:latest AS builder
 WORKDIR /app
 
 # Copy all go.mod and go.sum files to download dependencies efficiently
-COPY go.mod go.sum ./
+COPY go.work go.work.sum ./
 COPY apps/id_manager/go.mod apps/id_manager/go.sum ./apps/id_manager/
 COPY apps/client/go.mod apps/client/go.sum ./apps/client/
-COPY packages/crypto/go.mod ./packages/crypto/
+COPY common/go.mod ./common/
 
 # Set the workdir to the specific app we are building
 WORKDIR /app/apps/client
@@ -20,7 +20,7 @@ COPY . .
 
 # Build the application
 WORKDIR /app/apps/client
-RUN go build -o /client ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build -o /client ./cmd/main.go
 
 # Stage 2: Create the final, minimal image
 FROM alpine:latest

--- a/iac/docker-compose.local.yml
+++ b/iac/docker-compose.local.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+services:
+  id_manager:
+    image: eaglechat-id_manager:latest
+    ports:
+      - "8080:8080"
+    networks:
+      - eaglechat_net
+    volumes:
+      - id_manager_data:/data
+
+  client:
+    image: eaglechat-client:latest
+    networks:
+      - eaglechat_net
+    depends_on:
+      - id_manager
+    command: ["/client", "id_manager", "8080"]
+    stdin_open: true
+    tty: true
+
+networks:
+  eaglechat_net:
+    driver: overlay
+
+volumes:
+  id_manager_data:

--- a/iac/docker-compose.yml
+++ b/iac/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.8'
+
+services:
+  id_manager:
+    build:
+      context: ..
+      dockerfile: iac/id_manager/Dockerfile
+    ports:
+      # Expose port 8080 on the swarm's routing mesh to the host
+      - "8080:8080"
+    networks:
+      - eaglechat_net
+    volumes:
+      # Persist the user data using a named volume
+      - id_manager_data:/data
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          # Pin this service to a manager node to ensure it always uses
+          # the same data volume. For a real HA setup, this would
+          # require a distributed storage solution.
+          - node.role == manager
+
+  client:
+    build:
+      context: ..
+      dockerfile: iac/client/Dockerfile
+    networks:
+      - eaglechat_net
+    depends_on:
+      - id_manager
+    command: ["/client", "id_manager", "8080"]
+    stdin_open: true
+    tty: true
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          # Run the client on a worker node
+          - node.role == worker
+
+networks:
+  eaglechat_net:
+    # Use the overlay driver for multi-host swarm networking
+    driver: overlay
+
+volumes:
+  id_manager_data:
+    # Define the named volume for the id_manager data

--- a/iac/id_manager/Dockerfile
+++ b/iac/id_manager/Dockerfile
@@ -5,10 +5,11 @@ FROM golang:latest AS builder
 WORKDIR /app
 
 # Copy all go.mod and go.sum files to download dependencies efficiently
-# This leverages Docker's layer caching.
+COPY go.work go.work.sum ./
 COPY apps/id_manager/go.mod apps/id_manager/go.sum ./apps/id_manager/
 COPY apps/client/go.mod apps/client/go.sum ./apps/client/
-COPY packages/crypto/go.mod ./packages/crypto/
+COPY common/go.mod ./common/
+
 
 # Set the workdir to the specific app we are building to download its specific dependencies
 WORKDIR /app/apps/id_manager


### PR DESCRIPTION
This pull request adds changes in dockerfiles and adds docker-compose.yaml files to run the swarm locally and on serveral pcs. To test it locally this are the steps:
1 - Build both images:
- `docker build -t eaglechat-client:latest -f iac/client/Dockerfile .`
- `docker build -t eaglechat-id_manager:latest -f iac/id_manager/Dockerfile .`
2 - Init the swarm:
- `docker swarm init`
3 - Deploy the stack:
- `docker stack deploy -c iac/docker-compose.local.yml eaglechat`
With this yo should have the id manager and the client running in containers. For testing you can use.
- `curl http://127.0.0.1:8080/status` for testing the id manager. You should get an `{"status": "ok"}` response
- `docker ps --filter "name=eaglechat_client" --format "{{.Names}}"` will give you the name of the client container, then run `docker attach <name>` to attach to the client's terminal. If everything was done correctly and you have the latest image you should see the tui.

CLOSES: #16 