### PR TITLE
fix(id-manager): some fixes in gossip exchange logic

### DIFF
--- a/apps/id_manager/internal/application/ports/notifier.go
+++ b/apps/id_manager/internal/application/ports/notifier.go
@@ -5,6 +5,8 @@ import "context"
 // Notifier defines the interface for notifying peers of updates.
 // This abstraction helps break circular dependencies.
 type Notifier interface {
+	// GetPort returns the port on wich the notifier is running.
+	GetPort() string
 	NotifyPeersOfUpdate(ctx context.Context) error
 	// TriggerSyncFromPeer is used to initiate a data pull from a specific peer.
 	// This is typically called when a notification is received from that peer.

--- a/apps/id_manager/internal/application/services/gossip/gossip_service.go
+++ b/apps/id_manager/internal/application/services/gossip/gossip_service.go
@@ -90,6 +90,10 @@ func (s *GossipService) Stop() {
 	ezlog.Log(s.logCtx).Info("GossipService stopped")
 }
 
+func (s *GossipService) GetPort() string {
+	return s.gossipPort
+}
+
 // NotifyPeersOfUpdate sends a notification to a random peer to trigger a data pull.
 func (s *GossipService) NotifyPeersOfUpdate(ctx context.Context) error {
 	peers, err := s.peerProvider.DiscoverIDManagerIPs(ctx)
@@ -97,8 +101,10 @@ func (s *GossipService) NotifyPeersOfUpdate(ctx context.Context) error {
 		return fmt.Errorf("failed to discover peers for notification: %w", err)
 	}
 
+	validPeers := s.getAllValidPeers(peers)
+
 	var wg sync.WaitGroup
-	for _, peerIP := range s.getAllValidPeers(peers) {
+	for _, peerIP := range validPeers {
 		wg.Add(1)
 		go func(peerIP string) {
 			defer wg.Done()
@@ -109,7 +115,7 @@ func (s *GossipService) NotifyPeersOfUpdate(ctx context.Context) error {
 	}
 	wg.Wait()
 
-	ezlog.Log(s.logCtx).Infof("Successfully notified of updates to peers %v", peers)
+	ezlog.Log(s.logCtx).Infof("Successfully notified of updates to peers %v", validPeers)
 	return nil
 }
 
@@ -131,7 +137,7 @@ func (s *GossipService) TriggerSyncFromPeer(ctx context.Context, peerAddress str
 }
 
 func (s *GossipService) notifyPeer(ctx context.Context, peerIP string) error {
-	notificationURL := fmt.Sprintf("http://%s:%s/notify-update", peerIP, s.gossipPort)
+	notificationURL := fmt.Sprintf("http://%s:%s/notify-update", peerIP, s.GetPort())
 	requestBody, err := json.Marshal(map[string]string{"source_address": s.ownAddress})
 	if err != nil {
 		return fmt.Errorf("failed to marshal notification request body: %w", err)
@@ -293,7 +299,7 @@ func (s *GossipService) performPeriodicSync() {
 		return
 	}
 
-	peerAddress := fmt.Sprintf("%s:%s", peerIP, s.gossipPort)
+	peerAddress := fmt.Sprintf("%s:%s", peerIP, s.GetPort())
 	if err := s.TriggerSyncFromPeer(ctx, peerAddress); err != nil {
 		ezlog.Log(s.logCtx).Errorf("GossipService: Periodic sync failed: %v", err)
 	}

--- a/apps/id_manager/internal/application/usecases/gossip/gossip_dto.go
+++ b/apps/id_manager/internal/application/usecases/gossip/gossip_dto.go
@@ -24,13 +24,6 @@ type GossipExchangeResponse struct {
 	Envelope *simplecrypto.SecureEnvelope `json:"envelope"`
 }
 
-// GossipPayload is the internal data structure that is actually exchanged.
-// This struct will be marshaled to JSON and then encrypted inside the SecureEnvelope.
-type GossipPayload struct {
-	KnownPeers  map[string]PeerInfo `json:"known_peers"`
-	LastUpdated map[string]int64    `json:"last_updated"`
-}
-
 type PeerInfo struct {
 	Address string `json:"address"`
 	// other metadata

--- a/apps/id_manager/internal/infrastructure/http/handlers/notify_update_handler.go
+++ b/apps/id_manager/internal/infrastructure/http/handlers/notify_update_handler.go
@@ -1,9 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"eaglechat/apps/id_manager/internal/application/ports"
 	"eaglechat/common/ezlog"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -38,15 +41,19 @@ func (h *NotifyUpdateHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	ctx := c.Request.Context()
+	ezlog.Log(logCtx).Debugf("Received update-notification from source %s", req.SourceAddress)
+
 	// We run this in a goroutine to avoid blocking the caller.
 	// The caller (another ID manager) doesn't need to wait for our sync to complete.
-	go func() {
-		if err := h.notifier.TriggerSyncFromPeer(ctx, req.SourceAddress); err != nil {
+	go func(source string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := h.notifier.TriggerSyncFromPeer(ctx, source); err != nil {
 			// Log the error for observability, but we don't need to return an error to the caller.
 			ezlog.Log(logCtx).Errorf("NotifyUpdateHandler: failed to trigger sync from peer %s: %v", req.SourceAddress, err)
 		}
-	}()
+	}(fmt.Sprintf("%s:%s", req.SourceAddress, h.notifier.GetPort()))
 
 	c.JSON(http.StatusOK, gin.H{"status": "sync triggered"})
 }

--- a/apps/id_manager/internal/infrastructure/http/handlers/sync_data_handler.go
+++ b/apps/id_manager/internal/infrastructure/http/handlers/sync_data_handler.go
@@ -77,13 +77,21 @@ func (h *SyncDataHandler) Handle(c *gin.Context) {
 	}
 
 	// 4. Unmarshal the decrypted gossip payload
-	var peerGossipPayload gossip.GossipPayload
+	var peerGossipPayload usecases.SyncData
 	if err := json.Unmarshal(peerGossipBytes, &peerGossipPayload); err != nil {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Bad Request: Invalid gossip payload"})
 		return
 	}
 
-	ezlog.Log(logCtx).Infof("SyncDataHandler: Received and verified gossip from peer. KnownPeers: %+v", peerGossipPayload.KnownPeers)
+	ezlog.Log(logCtx).Infof("SyncDataHandler: Received and verified gossip from peer. Procceeding to merge data.")
+
+	// 4.5 Merge the incoming data into local repositories
+	if err := h.syncDataUC.MergeData(ctx, peerGossipPayload); err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "Internal server error merging data"})
+		return
+	}
+
+	ezlog.Log(logCtx).Infof("SyncDataHandler: Successfully merged gossip data from peer.")
 
 	// 5. Prepare this node's own gossip payload to send back.
 	myGossipData, err := h.syncDataUC.GetAllDataForSync(ctx)


### PR DESCRIPTION
Fix notify update handler concurrency issue
Added get gossip port to notifier interface
Fixed call to source address in notify update handle
Removed GossipPayload struct definition since it was useless and replaced it with sinc data
Added merge logic in syncdata handler
Fixed and added some logs
